### PR TITLE
Avances igor

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -14,6 +14,9 @@ db_password=alfresco
 alf_data_path=C:\Alfresco\alf_data
 java_path=C:\Alfresco\JDK11\jdk-11.0.11+9
 alfresco_base_path=C:\Alfresco\alfresco
+install_path=C:\Alfresco
+tengines_path=C:\Alfresco\tengines
+ass_path=C:\Alfresco\alfresco-search-services
 tomcat_path=C:\Alfresco\tomcat
 # View: https://tomcat.apache.org/tomcat-8.5-doc/windows-service-howto.html#Command_line_parameters
-tomcat_service_params=--JvmMs 1024 --JvmMx 4096
+tomcat_service_params=--JvmMs 1024 --JvmMx 4096 --Startup auto

--- a/pre_req.yml
+++ b/pre_req.yml
@@ -17,6 +17,7 @@
         - c:\Alfresco\installers
         - c:\Alfresco\installers\tmp
         - c:\Alfresco\JDK11
+        - "{{ tengines_path }}"
         - "{{ tomcat_path }}\\shared\\classes\\alfresco\\web-extension"
         - "{{ tomcat_path }}\\shared\\lib"
         - "{{ tomcat_path }}\\conf\\Catalina\\localhost"
@@ -87,15 +88,10 @@
       community.windows.win_unzip:
         src: C:\Alfresco\installers\ImageMagick-7.1.0-2-portable-Q16-x64.zip
         dest: c:\Alfresco\ImageMagick
-    - name: Unarchive solr6
+    - name: Unarchive Alfresco Search Services
       community.windows.win_unzip:
         src: C:\Alfresco\installers\alfresco-search-services-1.3.0.1.zip
-        dest: c:\Alfresco\alfresco
-    - name: Renaming a-s-s to solr6
-      win_shell: rename-item alfresco-search-services solr6
-      args:
-        chdir: C:\Alfresco\alfresco
-        creates: C:\Alfresco\alfresco\solr6
+        dest: "{{ install_path }}"
     - name: Downloading config files
       ansible.windows.win_get_url:
         url: "{{ item.url }}"
@@ -110,7 +106,6 @@
         - { url: 'https://raw.githubusercontent.com/Greencorecr/alfresco_windows/main/tomcat/tomcat-users.xml', dest: "{{ tomcat_path }}\\conf\\tomcat-users.xml" }
         - { url: 'https://raw.githubusercontent.com/Greencorecr/alfresco_windows/main/tomcat/context.xml', dest: "{{ tomcat_path }}\\conf\\context.xml" }
         - { url: 'https://jdbc.postgresql.org/download/postgresql-42.2.5.jar', dest: "{{ tomcat_path }}\\shared\\lib\\postgresql-42.2.5.jar" }
-        - { url: 'https://raw.githubusercontent.com/Greencorecr/alfresco_windows/main/search/shared.properties', dest: C:\Alfresco\alfresco\solr6\solrhome\conf\shared.properties } 
         - { url: 'https://downloads.loftux.net/public/content/org/alfresco/integrations/alfresco-googledocs-repo/3.0.4.3/alfresco-googledocs-repo-3.0.4.3.amp', dest: "{{ alfresco_base_path }}\\addons\\alfresco\\alfresco-googledocs-repo-3.0.4.3.amp" }
         - { url: 'https://downloads.loftux.net/public/content/org/alfresco/integrations/alfresco-googledocs-share/3.0.4.3/alfresco-googledocs-share-3.0.4.3.amp', dest: "{{ alfresco_base_path }}\\addons\\share\\alfresco-googledocs-share-3.0.4.3.amp" }
         - { url: 'https://downloads.loftux.net/public/content/org/alfresco/aos-module/alfresco-aos-module/1.2.2/alfresco-aos-module-1.2.2.amp', dest: "{{ alfresco_base_path }}\\addons\\alfresco\\alfresco-aos-module-1.2.2.amp" } 
@@ -126,6 +121,7 @@
         - { src: ./resources/tomcat/conf/server.xml, dest: "{{ tomcat_path }}\\conf\\server.xml" }
         - { src: ./resources/alf_data/keystore, dest: "{{ alf_data_path }}" }
         - { src: ./resources/share-config-custom.xml, dest: "{{ tomcat_path }}\\shared\\classes\\alfresco\\web-extension\\share-config-custom.xml" }
+        - { src: ./resources/alfresco-search-services/solrhome/conf/shared.properties, dest: "{{ ass_path }}\\solrhome\\conf\\shared.properties" }
     - name: Copy config templates
       ansible.windows.win_template:
         src: "{{ item.src }}"
@@ -153,24 +149,67 @@
         name:
         - nssm
         state: present
+    - name: Download T-Engines
+      ansible.windows.win_get_url:
+        url: "{{ item.url }}"
+        dest: "{{ item.dest }} "
+      loop:
+        - { url: 'https://artifacts.alfresco.com/nexus/service/local/repo_groups/public/content/org/alfresco/alfresco-transform-imagemagick-boot/2.5.1/alfresco-transform-imagemagick-boot-2.5.1.jar', dest: "{{ tengines_path }}\\alfresco-transform-imagemagick-boot-2.5.1.jar" }
+        - { url: 'https://artifacts.alfresco.com/nexus/service/local/repo_groups/public/content/org/alfresco/alfresco-transform-libreoffice-boot/2.5.1/alfresco-transform-libreoffice-boot-2.5.1.jar', dest: "{{ tengines_path }}\\alfresco-transform-libreoffice-boot-2.5.1.jar" }
+        - { url: 'https://artifacts.alfresco.com/nexus/service/local/repo_groups/public/content/org/alfresco/alfresco-transform-misc-boot/2.5.1/alfresco-transform-misc-boot-2.5.1.jar', dest: "{{ tengines_path }}\\alfresco-transform-misc-boot-2.5.1.jar" }
+        - { url: 'https://artifacts.alfresco.com/nexus/service/local/repo_groups/public/content/org/alfresco/alfresco-transform-pdf-renderer-boot/2.5.1/alfresco-transform-pdf-renderer-boot-2.5.1.jar', dest: "{{ tengines_path }}\\alfresco-transform-pdf-renderer-boot-2.5.1.jar" }
+        - { url: 'https://artifacts.alfresco.com/nexus/service/local/repo_groups/public/content/org/alfresco/alfresco-transform-tika-boot/2.5.1/alfresco-transform-tika-boot-2.5.1.jar', dest: "{{ tengines_path }}\\alfresco-transform-tika-boot-2.5.1.jar" }
+    - name: Configure T-Engines start scripts
+      ansible.windows.win_template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      loop:
+        - { src: ./resources/tengines/tengine-imagemagick.bat.j2, dest: "{{ tengines_path }}\\tengine-imagemagick.bat" }
+        - { src: ./resources/tengines/tengine-libreoffice.bat.j2, dest: "{{ tengines_path }}\\tengine-libreoffice.bat" }
+        - { src: ./resources/tengines/tengine-misc.bat.j2, dest: "{{ tengines_path }}\\tengine-misc.bat" }
+        - { src: ./resources/tengines/tengine-pdfrenderer.bat.j2, dest: "{{ tengines_path }}\\tengine-pdfrenderer.bat" }
+        - { src: ./resources/tengines/tengine-tika.bat.j2, dest: "{{ tengines_path }}\\tengine-tika.bat" }
+    - name: Creating services for T-engines
+      community.windows.win_nssm:
+        name: "{{ item.serviceName }}"
+        application: "{{ tengines_path }}\\{{ item.serviceName }}.bat"
+        start_mode: delayed
+        display_name: "{{ item.displayName }}"
+        description: "{{ item.displayName }}"
+      loop:
+        - { serviceName: tengine-imagemagick , displayName: " Image Magick Transformation Engine"}
+        - { serviceName: tengine-libreoffice , displayName: " Libre Office Transformation Engine"}
+        - { serviceName: tengine-misc , displayName: " Miscelanea Transformation Engine"}
+        - { serviceName: tengine-pdfrenderer , displayName: " Pdf Renderer Transformation Engine"}
+        - { serviceName: tengine-tika , displayName: " Tika Transformation Engine"}
     - name: Creating service for Nginx
       community.windows.win_nssm:
         name: nginx
         application: C:\Alfresco\nginx\nginx-1.21.0\nginx.exe
+        start_mode: delayed
+        display_name: Nginx
         description: Nginx
-    - name: Creating service for Solr
+    - name: Creating service for Alfresco Search Services
       community.windows.win_nssm:
-        name: solr
-        application: "{{ alfresco_base_path }}\\solr6\\solr\\bin\\solr.cmd"
+        name: alfresco-search-services
+        application: "{{ ass_path }}\\solr\\bin\\solr.cmd"
         arguments: start
-        description: Solr6
+        start_mode: delayed
+        display_name: Alfresco Search Services
+        description: Alfresco Search Services
     - name: Starting up services
       ansible.windows.win_service:
         name: "{{ item }}"
         state: started
       loop:
+        - Tomcat8
+        - alfresco-search-services
+        - tengine-imagemagick
+        - tengine-libreoffice
+        - tengine-misc
+        - tengine-pdfrenderer
+        - tengine-tika
         - nginx
-        - solr
 
 # TODO, traducir scripts
 # sudo curl -s -o $ALF_HOME/scripts/limitconvert.sh $BASE_DOWNLOAD/scripts/limitconvert.sh

--- a/pre_req.yml
+++ b/pre_req.yml
@@ -158,13 +158,6 @@
         name: nginx
         application: C:\Alfresco\nginx\nginx-1.21.0\nginx.exe
         description: Nginx
-    # Tomcat no funciona desde servicio, solo manual. TODO: Arreglar.
-    # "service.bat install Tomcat8" también falla.
-    - name: Creating service for Tomcat
-      community.windows.win_nssm:
-        name: tomcat
-        application: "{{ tomcat_path }}\\bin\\startup.bat"
-        description: tomcat
     - name: Creating service for Solr
       community.windows.win_nssm:
         name: solr
@@ -180,6 +173,4 @@
         - solr
 
 # TODO, traducir scripts
-# sudo $ALF_HOME/addons/apply.sh all
-# sudo curl -s -o $ALF_HOME/addons/apply.sh $BASE_DOWNLOAD/scripts/apply.sh
 # sudo curl -s -o $ALF_HOME/scripts/limitconvert.sh $BASE_DOWNLOAD/scripts/limitconvert.sh

--- a/pre_req.yml
+++ b/pre_req.yml
@@ -47,7 +47,7 @@
         path: https://downloads.apache.org/tomcat/tomcat-8/v8.5.68/bin/apache-tomcat-8.5.68.exe
         arguments: "/S /D={{ tomcat_path }}"
         state: present
-    - name: Increase JVM memory size
+    - name: Configure Tomcat Service
       win_shell: "{{ tomcat_path }}\\bin\\Tomcat8.exe //US// {{ tomcat_service_params }}"
     - name: Borrando aplicaciones default de tomcat
       ansible.windows.win_file:

--- a/resources/alfresco-global.properties.j2
+++ b/resources/alfresco-global.properties.j2
@@ -249,3 +249,17 @@ content.transformer.JodConverter.extensions.vsd.pdf.maxSourceSizeKBytes=5120
 content.transformer.JodConverter.extensions.vsdx.pdf.maxSourceSizeKBytes=5120
 content.transformer.JodConverter.extensions.ppsx.pdf.maxSourceSizeKBytes=5120
 
+# Alfresco Transform Service
+local.transform.service.enabled=true
+localTransform.pdfrenderer.url=http://localhost:8190/
+localTransform.imagemagick.url=http://localhost:8191/
+localTransform.libreoffice.url=http://localhost:8192/
+localTransform.tika.url=http://localhost:8193/
+localTransform.misc.url=http://localhost:8194/
+
+legacy.transform.service.enabled=true
+alfresco-pdf-renderer.url=http://localhost:8190/
+img.url=http://localhost:8191/
+jodconverter.url=http://localhost:8192/
+tika.url=http://localhost:8193/
+transform.misc.url=http://localhost:8194/

--- a/resources/alfresco-search-services/solrhome/conf/shared.properties
+++ b/resources/alfresco-search-services/solrhome/conf/shared.properties
@@ -1,3 +1,4 @@
+
 # Shared Properties file
 
 #Host details an external client would use to connect to Solr
@@ -12,17 +13,21 @@ alfresco.identifier.property.0={http://www.alfresco.org/model/content/1.0}creato
 alfresco.identifier.property.1={http://www.alfresco.org/model/content/1.0}modifier
 alfresco.identifier.property.2={http://www.alfresco.org/model/content/1.0}userName
 alfresco.identifier.property.3={http://www.alfresco.org/model/content/1.0}authorityName
+alfresco.identifier.property.4={http://www.alfresco.org/model/content/1.0}lockOwner
 
-# Suggestable Properties
-alfresco.suggestable.property.0={http://www.alfresco.org/model/content/1.0}name
-alfresco.suggestable.property.1={http://www.alfresco.org/model/content/1.0}title
-alfresco.suggestable.property.2={http://www.alfresco.org/model/content/1.0}description
-alfresco.suggestable.property.3={http://www.alfresco.org/model/content/1.0}content
+# Suggestable Propeties
+#alfresco.suggestable.property.0={http://www.alfresco.org/model/content/1.0}name
+#alfresco.suggestable.property.1={http://www.alfresco.org/model/content/1.0}title
+#alfresco.suggestable.property.2={http://www.alfresco.org/model/content/1.0}description
+#alfresco.suggestable.property.3={http://www.alfresco.org/model/content/1.0}content
 
 # Data types that support cross locale/word splitting/token patterns if tokenised
 alfresco.cross.locale.property.0={http://www.alfresco.org/model/content/1.0}name
+alfresco.cross.locale.property.1={http://www.alfresco.org/model/content/1.0}lockOwner
 
 # Data types that support cross locale/word splitting/token patterns if tokenised
 alfresco.cross.locale.datatype.0={http://www.alfresco.org/model/dictionary/1.0}text
 alfresco.cross.locale.datatype.1={http://www.alfresco.org/model/dictionary/1.0}content
 alfresco.cross.locale.datatype.2={http://www.alfresco.org/model/dictionary/1.0}mltext
+
+alfresco.model.tracker.cron=0/10 * * * * ? *

--- a/resources/create-db.sql.j2
+++ b/resources/create-db.sql.j2
@@ -1,3 +1,3 @@
 CREATE DATABASE {{ db_name }};
-CREATE USER alfresco WITH ENCRYPTED PASSWORD '{{ db_password }}';
+CREATE USER {{ db_user }} WITH ENCRYPTED PASSWORD '{{ db_password }}';
 GRANT ALL PRIVILEGES ON DATABASE {{ db_name }} TO {{ db_user}};

--- a/resources/tengines/tengine-imagemagick.bat.j2
+++ b/resources/tengines/tengine-imagemagick.bat.j2
@@ -1,0 +1,1 @@
+{{ java_path }}\bin\java.exe -Dserver.port=8191 -Dserver.address=localhost -jar {{ tengines_path}}\alfresco-transform-imagemagick-boot-2.5.1.jar

--- a/resources/tengines/tengine-libreoffice.bat.j2
+++ b/resources/tengines/tengine-libreoffice.bat.j2
@@ -1,0 +1,1 @@
+{{ java_path }}\bin\java.exe -Dserver.port=8192 -Dserver.address=localhost -jar {{ tengines_path}}\alfresco-transform-libreoffice-boot-2.5.1.jar

--- a/resources/tengines/tengine-misc.bat.j2
+++ b/resources/tengines/tengine-misc.bat.j2
@@ -1,0 +1,1 @@
+{{ java_path }}\bin\java.exe -Dserver.port=8194 -Dserver.address=localhost -jar {{ tengines_path}}\alfresco-transform-misc-boot-2.5.1.jar

--- a/resources/tengines/tengine-pdfrenderer.bat.j2
+++ b/resources/tengines/tengine-pdfrenderer.bat.j2
@@ -1,0 +1,1 @@
+{{ java_path }}\bin\java.exe -Dserver.port=8190 -Dserver.address=localhost -jar {{ tengines_path}}\alfresco-transform-pdf-renderer-boot-2.5.1.jar

--- a/resources/tengines/tengine-tika.bat.j2
+++ b/resources/tengines/tengine-tika.bat.j2
@@ -1,0 +1,1 @@
+{{ java_path }}\bin\java.exe -Dserver.port=8193 -Dserver.address=localhost -jar {{ tengines_path}}\alfresco-transform-tika-boot-2.5.1.jar


### PR DESCRIPTION
Este pull request quita la instalación de Tomcat8 mediante NSSM ya que no debiera ser necesaria.

También descarga y configura como servicios mediante NSSM las 5 T-engines estándar de Alfresco 6.2. Ya arrancan bien aunque muy probablemente aún no funcionen y requieran parametrización adicional.

Se vuelve a utilizar Alfresco Search Service como nombre para el componente de búsqueda en lugar de llamarlo solr o solr6 ya que no es un Solr estándar, es el específico de Alfresco con sus configuraciones y particularidades.