### PR TITLE
Ajustar JVM tomcat para usar UTF-8

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -24,7 +24,7 @@ ass_mem=-Xms2g -Xmx2g
 tomcat_path=C:\Alfresco\tomcat
 nginx_path=C:\Alfresco\nginx\nginx-1.21.0\
 
-tomcat_service_params=--JvmMs 1024 --JvmMx 4096 --Startup auto --LogPath C:\Alfresco\logs\tomcat --StartPath C:\Alfresco\logs\tomcat
+tomcat_service_params=--JvmMs 1024 --JvmMx 4096 --Startup auto --LogPath C:\Alfresco\logs\tomcat --StartPath C:\Alfresco\logs\tomcat --JvmOptions "-Dcatalina.home=C:\Alfresco\tomcat#-Dcatalina.base=C:\Alfresco\tomcat#-Djava.io.tmpdir=C:\Alfresco\tomcat\temp#-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager#-Djava.util.logging.config.file=C:\Alfresco\tomcat\conf\logging.properties#-Dfile.encoding=UTF-8"
 alfresco_hostname=gestordocumentaldes.rnpcr.priv
 clave_trazas=123clave
 mail_host=envio.rnpcr.priv


### PR DESCRIPTION
El no hacerlo causa problemas de encoding con la generación de ficheros y por ejemplo era el causante de los problemas de codificación del módulo de expedientes administrativos